### PR TITLE
Fix esp_sys_sem_create() in esp_sys_freertos_os.c

### DIFF
--- a/src/system/esp_sys_freertos_os.c
+++ b/src/system/esp_sys_freertos_os.c
@@ -104,9 +104,10 @@ uint8_t
 esp_sys_sem_create(esp_sys_sem_t* p, uint8_t cnt) {
     *p = xSemaphoreCreateBinary();
 
-    if (*p != NULL && !cnt) {
-        xSemaphoreTake(*p, 0);
+    if (*p != NULL && cnt) {
+        xSemaphoreGive(*p);
     }
+
     return *p != NULL;
 }
 


### PR DESCRIPTION
Fixes a hang that occur during initialization (in esp.c on line 109).
