### PR TITLE
Add compiler check for WPS config

### DIFF
--- a/lwesp/src/include/lwesp/lwesp_opt.h
+++ b/lwesp/src/include/lwesp/lwesp_opt.h
@@ -786,6 +786,11 @@ void *  my_memset(void* dst, int b, size_t len);
 #error "WPS function may only be used when station mode is enabled!"
 #endif /* LWESP_CFG_WPS && !LWESP_CFG_MODE_STATION */
 
+/* WPS config */
+#if LWESP_CFG_WPS && LWESP_CFG_MODE_STATION_ACCESS_POINT
+#error "WPS function may only be used with station mode enabled only!"
+#endif /* LWESP_CFG_WPS && LWESP_CFG_MODE_STATION_ACCESS_POINT */
+
 #endif /* !__DOXYGEN__ */
 
 #include "lwesp/lwesp_debug.h"


### PR DESCRIPTION
Hi, @MaJerle. Can you please test for WPS function with ap and station mode both enabled? Here on my device I got an error on WPS function with these two mode both enabled.
I test with
```C
assert(lwesp_init(0, 1) == lwespOK);
assert(lwesp_wps_set_config(1, 0, 0, 1) == lwespOK);
```
The output is:
```cmd
AT+CWMODE=3


OK
```
```cmd
AT+WPS=1

opmode mismatch when wps

ERROR

File xxx, line xxx, in function xxx
Assertion failed: lwesp_wps_set_config(1, 0, 0, 1) == lwespOK
```

And when station mode is enabled only, ESP can work properly. Disable ap mode:
```C
#define LWESP_CFG_MODE_ACCESS_POINT           0
```
The output is:
```cmd
AT+CWMODE=1


OK
```
```cmd
AT+WPS=1

wps started

OK
```