### PR TITLE
POSIX: use libc heap, allow NULL thread_t, UART refactored.

### DIFF
--- a/examples/posix/sntp_rtos/CMakeLists.txt
+++ b/examples/posix/sntp_rtos/CMakeLists.txt
@@ -26,6 +26,7 @@ set(C_SOURCES
     "../../../lwesp/src/lwesp/lwesp_utils.c"
     "../../../lwesp/src/lwesp/lwesp.c"
     "../../../lwesp/src/system/lwesp_ll_posix.c"
+    "../../../lwesp/src/system/lwesp_mem_posix.c"
     "../../../lwesp/src/system/lwesp_sys_posix.c"
     "main.c"
 )
@@ -43,6 +44,6 @@ set(C_LIBRARIES
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
 
-add_executable(${CMAKE_PROJECT_NAME} ${C_SOURCES})
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${C_INCLUDES})
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${C_LIBRARIES})
+add_executable(${PROJECT_NAME} ${C_SOURCES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${C_INCLUDES})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${C_LIBRARIES})

--- a/lwesp/src/system/lwesp_mem_posix.c
+++ b/lwesp/src/system/lwesp_mem_posix.c
@@ -1,6 +1,6 @@
 /**
- * \file            lwesp_opts.h
- * \brief           ESP application options
+ * \file            lwesp_mem_lwmem.c
+ * \brief           Dynamic memory manager implemented with LwMEM
  */
 
 /*
@@ -30,22 +30,41 @@
  *
  * Author:          Tilen MAJERLE <tilen@majerle.eu>
  * Author:          imi415 <imi415.public@gmail.com>
- * Version:         v1.1.0-dev
+ * Version:         v1.1.1-dev
  */
-#ifndef LWESP_HDR_OPTS_H
-#define LWESP_HDR_OPTS_H
+#include "lwesp/lwesp.h"
 
-/* Rename this file to "lwesp_opts.h" for your application */
+/* See lwesp_mem.c file for function documentation on parameters and return values */
+
+#if LWESP_CFG_MEM_CUSTOM && !__DOXYGEN__
 
 /*
- * Open "include/lwesp/lwesp_opt.h" and
- * copy & replace here settings you want to change values
+ * Before this driver can be used, user must:
+ *
+ *  - Configure LwMEM for thread-safety mode by enabling operating system features
+ *  - Set memory regions during start of application
  */
-#define LWESP_CFG_AT_ECHO                     1
-#define LWESP_CFG_INPUT_USE_PROCESS           1
 
-#define LWESP_CFG_SNTP                        1
+#include <stdlib.h>
 
-#define LWESP_CFG_MEM_CUSTOM                  1
+void*
+lwesp_mem_malloc(size_t size) {
+    return malloc(size);
+}
 
-#endif /* LWESP_HDR_OPTS_H */
+void*
+lwesp_mem_realloc(void* ptr, size_t size) {
+    return realloc(ptr, size);
+}
+
+void*
+lwesp_mem_calloc(size_t num, size_t size) {
+    return calloc(num, size);
+}
+
+void
+lwesp_mem_free(void* ptr) {
+    free(ptr);
+}
+
+#endif /* LWESP_CFG_MEM_CUSTOM && !__DOXYGEN__ */

--- a/lwesp/src/system/lwesp_sys_posix.c
+++ b/lwesp/src/system/lwesp_sys_posix.c
@@ -406,26 +406,35 @@ lwesp_sys_thread_create(lwesp_sys_thread_t* t, const char* name,
                         lwesp_sys_thread_fn thread_func, void* const arg,
                         size_t stack_size, lwesp_sys_thread_prio_t prio) {
 
-    *t = malloc(sizeof(pthread_t));
-    if (*t == NULL) {
+    pthread_t* new_thread = malloc(sizeof(pthread_t));
+    if (new_thread == NULL) {
         return 0;
     }
 
-    if (pthread_create(*t, NULL, (lwesp_sys_posix_thread_fn)thread_func, arg) != 0) {
+    if (pthread_create(new_thread, NULL, (lwesp_sys_posix_thread_fn)thread_func, arg) != 0) {
         free(*t);
         return 0;
     };
+
+    if (t != NULL) {
+        *t = new_thread;
+    } else {
+        free(new_thread);
+    }
 
     return 1;
 }
 
 uint8_t
 lwesp_sys_thread_terminate(lwesp_sys_thread_t* t) {
-    if (pthread_cancel(**t) != 0) {
-        return 0;
+    if (t != NULL && *t != NULL) {
+        if (pthread_cancel(**t) != 0) {
+            return 0;
+        }
+
+        free(*t);
     }
 
-    free(*t);
     return 1;
 }
 


### PR DESCRIPTION
1. Allow null lwesp_sys_thread_t pointers during thread creation and termination
2. Switch to native libc heap memory management
3. Refactored UART recv thread, fixed TCP send issues.