### PR TITLE
MQTT over SSL preserving API

### DIFF
--- a/lwesp/src/apps/mqtt/lwesp_mqtt_client.c
+++ b/lwesp/src/apps/mqtt/lwesp_mqtt_client.c
@@ -29,7 +29,7 @@
  * This file is part of LwESP - Lightweight ESP-AT parser library.
  *
  * Author:          Tilen MAJERLE <tilen@majerle.eu>
- * Version:         v1.0.0
+ * Version:         v1.1.0-dev
  */
 #include "lwesp/apps/lwesp_mqtt_client.h"
 #include "lwesp/lwesp_mem.h"
@@ -1155,7 +1155,12 @@ lwesp_mqtt_client_connect(lwesp_mqtt_client_p client, const char* host, lwesp_po
         client->evt_fn = evt_fn != NULL ? evt_fn : mqtt_evt_fn_default;
 
         /* Start a new connection in non-blocking mode */
-        res = lwesp_conn_start(&client->conn, LWESP_CONN_TYPE_TCP, host, port, client, mqtt_conn_cb, 0);
+        if (info->ssl){
+			res = lwesp_conn_start(&client->conn, LWESP_CONN_TYPE_SSL, host, port, client, mqtt_conn_cb, 0);
+		}
+		else {
+			res = lwesp_conn_start(&client->conn, LWESP_CONN_TYPE_TCP, host, port, client, mqtt_conn_cb, 0);
+		}
         if (res == lwespOK) {
             client->conn_state = LWESP_MQTT_CONN_CONNECTING;
         }

--- a/lwesp/src/include/lwesp/apps/lwesp_mqtt_client.h
+++ b/lwesp/src/include/lwesp/apps/lwesp_mqtt_client.h
@@ -29,13 +29,14 @@
  * This file is part of LwESP - Lightweight ESP-AT parser library.
  *
  * Author:          Tilen MAJERLE <tilen@majerle.eu>
- * Version:         v1.0.0
+ * Version:         v1.1.0-dev
  */
 #ifndef LWESP_HDR_APP_MQTT_CLIENT_H
 #define LWESP_HDR_APP_MQTT_CLIENT_H
 
 #include "lwesp/lwesp.h"
 #include "lwesp/apps/lwesp_mqtt_client_evt.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,6 +91,7 @@ typedef struct {
     const char* will_topic;                     /*!< Will topic */
     const char* will_message;                   /*!< Will message */
     lwesp_mqtt_qos_t will_qos;                  /*!< Will topic quality of service */
+    bool ssl;									/*!< SSL Connection */
 } lwesp_mqtt_client_info_t;
 
 /**


### PR DESCRIPTION
Allow SSL connection to be specified for MQTT by adding a boolean into lwesp_mqtt_client_info_t.