### PR TITLE
Add lwesp_mfg_read for reading back certificate stored in MFG area

### DIFF
--- a/lwesp/src/include/lwesp/lwesp_flash.h
+++ b/lwesp/src/include/lwesp/lwesp_flash.h
@@ -58,7 +58,7 @@ lwespr_t lwesp_mfg_write(lwesp_mfg_namespace_t namespace, const char* key, lwesp
                          const void* data, uint32_t length, const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg,
                          const uint32_t blocking);
 lwespr_t lwesp_mfg_read(lwesp_mfg_namespace_t namespace, const char* key, const void* data, uint32_t len,
-                const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg, const uint32_t blocking);
+                        const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg, const uint32_t blocking);
 
 /**
  * \}

--- a/lwesp/src/include/lwesp/lwesp_flash.h
+++ b/lwesp/src/include/lwesp/lwesp_flash.h
@@ -57,6 +57,8 @@ lwespr_t lwesp_mfg_erase(lwesp_mfg_namespace_t namespace, const char* key, uint3
 lwespr_t lwesp_mfg_write(lwesp_mfg_namespace_t namespace, const char* key, lwesp_mfg_valtype_t valtype,
                          const void* data, uint32_t length, const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg,
                          const uint32_t blocking);
+lwespr_t lwesp_mfg_read(lwesp_mfg_namespace_t namespace, const char* key, const void* data, uint32_t len,
+                const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg, const uint32_t blocking);
 
 /**
  * \}

--- a/lwesp/src/include/lwesp/lwesp_private.h
+++ b/lwesp/src/include/lwesp/lwesp_private.h
@@ -691,7 +691,7 @@ typedef struct {
 
 /**
  * \brief           Physical device descriptor data
- *
+ * 
  * This is used for library internal reasons
  */
 typedef struct {

--- a/lwesp/src/include/lwesp/lwesp_private.h
+++ b/lwesp/src/include/lwesp/lwesp_private.h
@@ -574,7 +574,7 @@ typedef struct lwesp_msg {
                 uint32_t u32;
                 int32_t i32;
             } data_prim;
-        } mfg_write; /*!< Flash write */
+        } mfg_write_read; /*!< Flash write */
 #endif
     } msg; /*!< Group of different message contents */
 } lwesp_msg_t;
@@ -691,7 +691,7 @@ typedef struct {
 
 /**
  * \brief           Physical device descriptor data
- * 
+ *
  * This is used for library internal reasons
  */
 typedef struct {

--- a/lwesp/src/include/lwesp/lwesp_private.h
+++ b/lwesp/src/include/lwesp/lwesp_private.h
@@ -563,7 +563,7 @@ typedef struct lwesp_msg {
             const char* key;                 /*!< Key to write */
             lwesp_mfg_valtype_t valtype;     /*!< Value type */
             uint32_t length;                 /*!< Length of data */
-            const void* data_ptr;            /*!< Data pointer to write. Used for non-primitive types */
+            void* data_ptr;                  /*!< Data pointer to write. Used for non-primitive types */
             uint8_t wait_second_ok;          /*!< Set to `1` to wait for second OK */
 
             union {

--- a/lwesp/src/lwesp/lwesp_flash.c
+++ b/lwesp/src/lwesp/lwesp_flash.c
@@ -99,10 +99,10 @@ lwesp_flash_write(lwesp_flash_partition_t partition, uint32_t offset, const void
 
 /**
  * \brief           Write key-value pair into user MFG area.
- *
+ * 
  * \note            When writing into this section, no need to previously erase the data
  *                  System is smart enough to do this for us, if absolutely necessary
- *
+ * 
  * \param           namespace: User namespace option
  * \param           key: Key to write
  * \param           valtype: Value type to follow

--- a/lwesp/src/lwesp/lwesp_flash.c
+++ b/lwesp/src/lwesp/lwesp_flash.c
@@ -147,10 +147,18 @@ lwesp_mfg_write(lwesp_mfg_namespace_t namespace, const char* key, lwesp_mfg_valt
         switch (valtype) {
             case LWESP_MFG_VALTYPE_U8: LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.u8 = *(uint8_t*)data; break;
             case LWESP_MFG_VALTYPE_I8: LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.i8 = *(int8_t*)data; break;
-            case LWESP_MFG_VALTYPE_U16: LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.u16 = *(uint16_t*)data; break;
-            case LWESP_MFG_VALTYPE_I16: LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.i16 = *(int16_t*)data; break;
-            case LWESP_MFG_VALTYPE_U32: LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.u32 = *(uint32_t*)data; break;
-            case LWESP_MFG_VALTYPE_I32: LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.i32 = *(int32_t*)data; break;
+            case LWESP_MFG_VALTYPE_U16:
+                LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.u16 = *(uint16_t*)data;
+                break;
+            case LWESP_MFG_VALTYPE_I16:
+                LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.i16 = *(int16_t*)data;
+                break;
+            case LWESP_MFG_VALTYPE_U32:
+                LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.u32 = *(uint32_t*)data;
+                break;
+            case LWESP_MFG_VALTYPE_I32:
+                LWESP_MSG_VAR_REF(msg).msg.mfg_write_read.data_prim.i32 = *(int32_t*)data;
+                break;
             default: break; /* Length as-is */
         }
     } else {
@@ -163,11 +171,10 @@ lwesp_mfg_write(lwesp_mfg_namespace_t namespace, const char* key, lwesp_mfg_valt
 /**
  * \brief           Read key-value pair from user MFG area.
  *
- *
  * \param           namespace: User namespace option
  * \param           key: Key to read
  * \param           data: Pointer to buffer to write data to.
- * \param           len: Size of data buffer
+ * \param           len: Size of data buffer. Must be same size as stored certificate in MFG area.
  * \param[in]       evt_fn: Callback function called when command has finished. Set to `NULL` when not used
  * \param[in]       evt_arg: Custom argument for event callback function
  * \param[in]       blocking: Status whether command should be blocking or not
@@ -175,7 +182,7 @@ lwesp_mfg_write(lwesp_mfg_namespace_t namespace, const char* key, lwesp_mfg_valt
  */
 lwespr_t
 lwesp_mfg_read(lwesp_mfg_namespace_t namespace, const char* key, const void* data, uint32_t len,
-                const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg, const uint32_t blocking) {
+               const lwesp_api_cmd_evt_fn evt_fn, void* const evt_arg, const uint32_t blocking) {
     LWESP_MSG_VAR_DEFINE(msg);
 
     LWESP_ASSERT(namespace < LWESP_MFG_NAMESPACE_END);

--- a/lwesp/src/lwesp/lwesp_int.c
+++ b/lwesp/src/lwesp/lwesp_int.c
@@ -2572,7 +2572,7 @@ lwespi_initiate_cmd(lwesp_msg_t* msg) {
         case LWESP_CMD_TCPIP_CIPSTART: {
             const char* conn_type_str;
 #if LWESP_CFG_CONN_ALLOW_START_STATION_NO_IP
-            /*
+            /* 
              * Do not check IP status if starting a connection is allowed
              * without being connected to access point.
              * This allows ESP to act as a access point and get connected another station to it.

--- a/lwesp/src/lwesp/lwesp_int.c
+++ b/lwesp/src/lwesp/lwesp_int.c
@@ -1616,7 +1616,7 @@ lwespi_process(const void* data, size_t data_len) {
                         /*
                          * This part handles the response of "+CIPRECVDATA",
                          * that does not end with CRLF, rather string continues with user data.
-                         *
+                         * 
                          * We cannot rely on line processing.
                          *
                          * +CIPRECVDATA:<len>,<IP>,<port>,data...

--- a/lwesp/src/lwesp/lwesp_int.c
+++ b/lwesp/src/lwesp/lwesp_int.c
@@ -2572,7 +2572,7 @@ lwespi_initiate_cmd(lwesp_msg_t* msg) {
         case LWESP_CMD_TCPIP_CIPSTART: {
             const char* conn_type_str;
 #if LWESP_CFG_CONN_ALLOW_START_STATION_NO_IP
-            /* 
+            /*
              * Do not check IP status if starting a connection is allowed
              * without being connected to access point.
              * This allows ESP to act as a access point and get connected another station to it.
@@ -3007,9 +3007,9 @@ lwespi_process_events_for_timeout_or_error(lwesp_msg_t* msg, lwespr_t err) {
 
 /**
  * \brief           Get internal ESP device descriptor information
- * 
+ *
  * \param           device: Required device ID
- * \return          Pointer to device descriptor, or NULL if not device available 
+ * \return          Pointer to device descriptor, or NULL if not device available
  */
 const lwesp_esp_device_desc_t*
 lwespi_get_device_desc_for_device(lwesp_device_t device) {

--- a/lwesp/src/lwesp/lwesp_int.c
+++ b/lwesp/src/lwesp/lwesp_int.c
@@ -1140,25 +1140,25 @@ lwespi_parse_received(lwesp_recv_t* rcv) {
                 }
             }
         } else if (CMD_IS_CUR(LWESP_CMD_SYSMFG_READ)) {
-        	if(!strncmp(rcv->data, "+SYSMFG:", 8)){
-				char *ptrBeginCert = strstr(rcv->data, "-----BEGIN CERTIFICATE-----\n");
-				if(ptrBeginCert != NULL && esp.msg->msg.mfg_write_read.data_ptr != NULL){
-					uint32_t len = strlen("-----BEGIN CERTIFICATE-----\n");
-					LWESP_MEMCPY(esp.msg->msg.mfg_write_read.data_ptr, ptrBeginCert, len);
-					esp.msg->msg.mfg_write_read.data_ptr += len;
-					esp.msg->msg.mfg_write_read.length -= len;
-					esp.msg->msg.mfg_write_read.wait_second_ok = 1;
-				}
-        	}else if(esp.msg->msg.mfg_write_read.wait_second_ok){
-        		LWESP_MEMCPY(esp.msg->msg.mfg_write_read.data_ptr, rcv->data, rcv->len);
-        		esp.msg->msg.mfg_write_read.data_ptr += rcv->len;
-        		esp.msg->msg.mfg_write_read.length -= rcv->len;
-        		if(esp.msg->msg.mfg_write_read.length == 0){
-        			esp.msg->res = lwespOK;
-        		}else{
-        			esp.msg->res = lwespERR;
-        		}
-        	}
+            if (!strncmp(rcv->data, "+SYSMFG:", 8)) {
+                char* ptrBeginCert = strstr(rcv->data, "-----BEGIN CERTIFICATE-----\n");
+                if (ptrBeginCert != NULL && esp.msg->msg.mfg_write_read.data_ptr != NULL) {
+                    uint32_t len = strlen("-----BEGIN CERTIFICATE-----\n");
+                    LWESP_MEMCPY(esp.msg->msg.mfg_write_read.data_ptr, ptrBeginCert, len);
+                    esp.msg->msg.mfg_write_read.data_ptr += len;
+                    esp.msg->msg.mfg_write_read.length -= len;
+                    esp.msg->msg.mfg_write_read.wait_second_ok = 1;
+                }
+            } else if (esp.msg->msg.mfg_write_read.wait_second_ok) {
+                LWESP_MEMCPY(esp.msg->msg.mfg_write_read.data_ptr, rcv->data, rcv->len);
+                esp.msg->msg.mfg_write_read.data_ptr += rcv->len;
+                esp.msg->msg.mfg_write_read.length -= rcv->len;
+                if (esp.msg->msg.mfg_write_read.length == 0) {
+                    esp.msg->res = lwespOK;
+                } else {
+                    esp.msg->res = lwespERR;
+                }
+            }
 #endif /* LWESP_CFG_FLASH */
         } else if (CMD_IS_CUR(LWESP_CMD_TCPIP_CIPSTART)) {
             /* Do nothing, it is either OK or not OK */
@@ -1609,7 +1609,8 @@ lwespi_process(const void* data, size_t data_len) {
                         if (!LWESP_MFG_VALTYPE_IS_PRIM(esp.msg->msg.mfg_write_read.valtype) && ch == '>'
                             && ch_prev1 == '\n') {
                             RECV_RESET(); /* Reset received object */
-                            AT_PORT_SEND_WITH_FLUSH(esp.msg->msg.mfg_write_read.data_ptr, esp.msg->msg.mfg_write_read.length);
+                            AT_PORT_SEND_WITH_FLUSH(esp.msg->msg.mfg_write_read.data_ptr,
+                                                    esp.msg->msg.mfg_write_read.length);
                         }
 #endif /* LWESP_CFG_FLASH */
 #if LWESP_CFG_CONN_MANUAL_TCP_RECEIVE

--- a/lwesp/src/lwesp/lwesp_int.c
+++ b/lwesp/src/lwesp/lwesp_int.c
@@ -1412,7 +1412,7 @@ lwespi_process(const void* data, size_t data_len) {
         /*
          * This is auto read for UDP connections,
          * or if random connection sends data out w/o manual request!
-         *
+         * 
          * It is critual to support automatic mode too
          */
         if (esp.m.ipd.read) {
@@ -3007,9 +3007,9 @@ lwespi_process_events_for_timeout_or_error(lwesp_msg_t* msg, lwespr_t err) {
 
 /**
  * \brief           Get internal ESP device descriptor information
- *
+ * 
  * \param           device: Required device ID
- * \return          Pointer to device descriptor, or NULL if not device available
+ * \return          Pointer to device descriptor, or NULL if not device available 
  */
 const lwesp_esp_device_desc_t*
 lwespi_get_device_desc_for_device(lwesp_device_t device) {


### PR DESCRIPTION
I added the feature for reading back the certificates stored in the MFG area.

- Added the function lwesp_mfg_area in lwesp_flash.c.
- Added mechanism for receiving the cert from ESP and storing it in the user supplied buffer.

It works fine, tested it with different namespaces and keys.

I am not sure on how to detect the beginning of the actual certificate in the input_process. Currently I am searching for "-----BEGIN CERTIFICATE-----\n" in the input process and then down-counting the received bytes until it matches the supplied length.
Feedback is very much appreciated!